### PR TITLE
mv react-native to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/nick/react-native-carousel/issues"
   },
   "homepage": "https://github.com/nick/react-native-carousel",
-  "dependencies": {
-    "react-native": "^0.4.0"
+  "peerDependencies": {
+    "react-native": ">=0.4 <1.0"
   }
 }


### PR DESCRIPTION
thanks for the lib :)

having react-native as a dependency breaks things: https://github.com/facebook/react-native/issues/1606

also, semver major 0 is a dick: https://github.com/npm/node-semver/issues/79  ">=0.4 <1.0" works, "^0.4.0" doesn't
