### PR TITLE
Remove duplicate width calculation when initialPage is defined

### DIFF
--- a/Carousel.js
+++ b/Carousel.js
@@ -47,7 +47,7 @@ var Carousel = React.createClass({
       this.setState({
         activePage: this.props.initialPage
       });
-      this.refs.scrollView.scrollWithoutAnimationTo(0, this.props.initialPage * width);
+      this.refs.scrollView.scrollWithoutAnimationTo(0, width);
     }
 
     if (this.props.animate && this.props.children){


### PR DESCRIPTION
Fix minor bug to make initialPage usable. Now it's not working properly because scrollview gets `this.props.initialPage*this.props.initialPage*width`. 