### PR TITLE
Destructured Dimension import

### DIFF
--- a/Carousel.js
+++ b/Carousel.js
@@ -2,6 +2,7 @@
 
 var React = require('react-native');
 var {
+  Dimensions,
   StyleSheet,
   View,
   Text,
@@ -10,7 +11,6 @@ var {
 
 var TimerMixin = require('react-timer-mixin');
 
-var Dimensions = require('Dimensions');
 var { width, height} = Dimensions.get('window');
 
 


### PR DESCRIPTION
In react-native 0.14.2, directly `require()`ing `Dimension` throws a packager error. It should be imported via the destructuring syntax instead. 

See:
https://github.com/facebook/react-native/issues/3817