### PR TITLE
Remove call to _animateNextPage() after page has been changed

### DIFF
--- a/Carousel.js
+++ b/Carousel.js
@@ -124,8 +124,6 @@ var Carousel = React.createClass({
       activePage: activePage
     });
 
-    this._animateNextPage();
-    
     if (this.props.onPageChange) {
       this.props.onPageChange(activePage);
     }


### PR DESCRIPTION
_animateNextPage was causing the carousel to loop forever