### PR TITLE
misc: change default indicatorOffset to 10

### DIFF
--- a/Carousel.js
+++ b/Carousel.js
@@ -23,7 +23,7 @@ var Carousel = React.createClass({
       indicatorSize: 50,
       inactiveIndicatorColor: '#999999',
       indicatorAtBottom: true,
-      indicatorOffset: 250,
+      indicatorOffset: 10,
       width: width,
       initialPage: 0,
       indicatorSpace: 25,


### PR DESCRIPTION
If user don't set indicatorOffset explictly , meanwhile the height of subview of ScrollView is below 250, the indicatorOffset default value will lead to PageControl be disappeared from user's sight.

I think indicatorOffset=10 will avoid to be in such embarrassing situation that i was today.
