### PR TITLE
Call createClass on React instead of React Native

### DIFF
--- a/Carousel.js
+++ b/Carousel.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var {
   Dimensions,
   StyleSheet,
   Text,
   View,
-} = React;
+} = require('react-native');
 
 var TimerMixin = require('react-timer-mixin');
 var CarouselPager = require('./CarouselPager');

--- a/CarouselPager.android.js
+++ b/CarouselPager.android.js
@@ -1,8 +1,8 @@
-var React = require('react-native');
+var React = require('react');
 var {
   View,
   ViewPagerAndroid,
-} = React;
+} = require('react-native');
 
 var CarouselPager = React.createClass({
 

--- a/CarouselPager.ios.js
+++ b/CarouselPager.ios.js
@@ -1,7 +1,7 @@
-var React = require('react-native');
+var React = require('react');
 var {
   ScrollView,
-} = React;
+} = require('react-native');
 
 var CarouselPager = React.createClass({
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/nick/react-native-carousel",
   "dependencies": {
+    "react": "^15.0.2",
     "react-timer-mixin": "^0.13.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
[React Native 0.25.1](https://github.com/facebook/react-native/releases/tag/v0.25.1) introduces a deprecation on calling certain methods on `React` instead of `React Native`.

This PR adds a dependency on React to remove the deprecation warning in 0.25.1