### PR TITLE
Enabling custom indicator content

### DIFF
--- a/Carousel.js
+++ b/Carousel.js
@@ -22,6 +22,8 @@ var Carousel = React.createClass({
       inactiveIndicatorColor: '#999999',
       indicatorAtBottom: true,
       indicatorOffset: 250,
+      indicatorText: '•',
+      inactiveIndicatorText: '•',
       width: null,
       initialPage: 0,
       indicatorSpace: 25,
@@ -80,7 +82,15 @@ var Carousel = React.createClass({
       }
 
       style = i === this.state.activePage ? { color: this.props.indicatorColor } : { color: this.props.inactiveIndicatorColor };
-      indicators.push(<Text style={[style, { fontSize: this.props.indicatorSize }]} key={i} onPress={this.indicatorPressed.bind(this,i)}>&bull;</Text>);
+      indicators.push(
+         <Text 
+            style={[style, { fontSize: this.props.indicatorSize }]} 
+            key={i} 
+            onPress={this.indicatorPressed.bind(this,i)}
+          >
+             { i === this.state.activePage  ? this.props.indicatorText : this.props.inactiveIndicatorText }
+          </Text>
+      );
     }
 
     if (indicators.length === 1) {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ inactiveIndicatorColor="#999999" // Inactive indicator color
 indicatorAtBottom={true} // Set to false to show the indicators at the top
 indicatorOffset={250} // Indicator relative position from top or bottom
 onPageChange={callback} // Called when the active page changes
+inactiveIndicatorText= '•' // Inactive indicator content ( You can customize to use any Unicode character )
+indicatorText= '•' // Active indicator content ( You can customize to use any Unicode character )
 
 animate={true} // Enable carousel autoplay
 delay={1000} // Set Animation delay between slides


### PR DESCRIPTION
Hi,

This PR is for customizing the indicator text. As of now, the indicator show only `&bull;` html character. With this PR, we should be able to add any custom html characters.

My requirement was to achieve this:

![screenshot](http://g.recordit.co/LDmuUnig7X.gif)

And, now I am able to do it by passing these props:

```js

{
     inactiveIndicatorText: '○',
     indicatorText: '●',
}

```
