### PR TITLE
Use getWidth() and wrapping children to have consistent width

### DIFF
--- a/Carousel.js
+++ b/Carousel.js
@@ -29,7 +29,7 @@ var Carousel = React.createClass({
       indicatorSpace: 25,
       animate: true,
       delay: 1000,
-      loop: true,
+      loop: true
     };
   },
 
@@ -135,12 +135,17 @@ var Carousel = React.createClass({
   },
 
   render() {
+    let width = this.getWidth()
+    let style = {
+      flex: 1,
+      width: width
+    }
+
     return (
-      <View style={{ flex: 1 }}>
+      <View style={style}>
         <CarouselPager
           ref="pager"
-          width={this.getWidth()}
-          contentContainerStyle={styles.container}
+          width={width}
           onBegin={this._onAnimationBeginPage}
           onEnd={this._onAnimationEnd}
         >

--- a/CarouselPager.ios.js
+++ b/CarouselPager.ios.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var {
   ScrollView,
+  View
 } = require('react-native');
 
 var CarouselPager = React.createClass({
@@ -29,9 +30,13 @@ var CarouselPager = React.createClass({
       onMomentumScrollEnd={this._onMomentumScrollEnd}
       scrollsToTop={false}
     >
-      {this.props.children}
+      {React.Children.map(this.props.children, this.setWidth)}
     </ScrollView>;
   },
+
+  setWidth(child) {
+    return (<View style={{ width: this.props.width }}>{child}</View>)
+  }
 });
 
 module.exports = CarouselPager;


### PR DESCRIPTION
I was trying to get a full-width carousel, which wasn't that easy.  This might be an improvement, as it assumes full width if no explicit width is set on the Carousel, and pulls that width through as appropriate if it is set.

The wrapping of the children means that they all have consistent width without the width having to be set explicitly.  The only thing I don't like about this is creating another View node in the process.

This could be carried further by listening for orientation changes and then pushing the change in width down the component tree.