### PR TITLE
Closes #83 added support for React v.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+# JetBrains IDEs
+.idea

--- a/Carousel.js
+++ b/Carousel.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var {
   Dimensions,
   StyleSheet,
@@ -11,7 +12,7 @@ var {
 var TimerMixin = require('react-timer-mixin');
 var CarouselPager = require('./CarouselPager');
 
-var Carousel = React.createClass({
+var Carousel = createReactClass({
   mixins: [TimerMixin],
 
   getDefaultProps() {

--- a/CarouselPager.android.js
+++ b/CarouselPager.android.js
@@ -1,10 +1,11 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var {
   View,
   ViewPagerAndroid,
 } = require('react-native');
 
-var CarouselPager = React.createClass({
+var CarouselPager = createReactClass({
 
   scrollToPage(page, animated) {
     if (typeof animated === 'undefined') {

--- a/CarouselPager.ios.js
+++ b/CarouselPager.ios.js
@@ -1,9 +1,10 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var {
   ScrollView,
 } = require('react-native');
 
-var CarouselPager = React.createClass({
+var CarouselPager = createReactClass({
 
   scrollToPage(page, animated) {
     if (typeof animated === 'undefined') {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-timer-mixin": "^0.13.3"
   },
   "peerDependencies": {
-    "react-native": ">=0.28 <1.0"
+    "react-native": ">=0.28 <1.0",
+    "create-react-class": ">=15.6.2"
   }
 }


### PR DESCRIPTION
Since React.createClass is removed from React v.16 had to use a drop-in replacement from 'create-react-class'